### PR TITLE
Proposal to add context managers to comdb2.cdb2

### DIFF
--- a/docs/cdb2.rst
+++ b/docs/cdb2.rst
@@ -18,6 +18,18 @@ The user interacts with the database using `Handle` objects.
 
     .. automethod:: __iter__
 
+.. autoclass:: ClosingHandle
+    :members:
+
+    .. automethod:: __enter__
+    .. automethod:: __exit__
+
+.. autoclass:: TransactionHandle
+    :members:
+
+    .. automethod:: __enter__
+    .. automethod:: __exit__
+
 Exceptions
 ----------
 


### PR DESCRIPTION
In order to make it clear that using a context manager is the recommended way of using a Handle, I've drafted two new classes which wrap Handle and act as context managers.  In my mind, using a module provided contextmanager over one provided by the standard library makes it obvious that the programmer is using comdb2.cdb2 in an approved way.
Of course, semantically similar versions of these two new classes should also be added to comdb2.dbapi2 for the sake of consistency.  I'm not in love with the manager names, so any name suggestions would be appreciated.