### PR TITLE
Fix DB-API 2.0 description inconsistency

### DIFF
--- a/comdb2/dbapi2.py
+++ b/comdb2/dbapi2.py
@@ -962,7 +962,8 @@ class Cursor(object):
                 raise InterfaceError(errmsg)
 
         self._execute(operation, sql, parameters)
-        self._load_description()
+        if self._rowcount == -1:
+            self._load_description()
         # Optional DB API Extension: execute's return value is unspecified.  We
         # return an iterable over the rows, but this isn't portable across DBs.
         return self
@@ -1123,7 +1124,7 @@ class Cursor(object):
     # Optional DB API Extension
     def next(self):
         self._check_closed()
-        if not self._description or self._rowcount != -1:
+        if not self._description:
             raise InterfaceError("No result set exists")
         try:
             return next(self._hndl)

--- a/tests/test_dbapi2.py
+++ b/tests/test_dbapi2.py
@@ -823,6 +823,7 @@ def test_datetimeus():
 def test_interface_error_reading_result_set_after_commits():
     hndl = connect('mattdb', 'dev')
     cursor = hndl.cursor().execute("delete from simple where 1=1")
+    assert cursor.description is None
     hndl.commit()
     with pytest.raises(InterfaceError) as exc_info:
         cursor.fetchall()
@@ -830,6 +831,7 @@ def test_interface_error_reading_result_set_after_commits():
 
     hndl = connect('mattdb', 'dev', autocommit=True)
     cursor = hndl.cursor().execute("delete from simple where 1=1")
+    assert cursor.description is None
     with pytest.raises(InterfaceError) as exc_info:
         cursor.fetchall()
     assert "No result set exists" in str(exc_info.value)


### PR DESCRIPTION
We already blocked retrieving rows from a cursor when we've set `rowcount`, but we were still setting `description`.

This makes the behavior consistent, so that `description` is only set when we're exposing a result set that can be described.