### PR TITLE
Work on directly supporting the context manager.

### DIFF
--- a/comdb2/cdb2.py
+++ b/comdb2/cdb2.py
@@ -409,3 +409,29 @@ class Handle(object):
             object exposed by this module.
         """
         return self._hndl.column_types()
+
+    def isOpen(self):
+        """Checks if the connection is (apparently) open.  This method is
+           intended to be used from within this class as well as external
+           callers.
+
+        Returns:
+            The boolean value True if the connection is (apparently) open.
+        """
+        return bool(self._hndl is not None)
+
+    def __enter__(self):
+        """This method is called by the context manager when a `with` block
+           is exited.  Currently, it does nothing.
+        """
+        pass
+
+    def __exit__(self):
+        """This method is called by the context manager when a `with` block
+           is exited.  It is designed to close the connection unless it has
+           already been closed.  In that case, it does nothing.
+        """
+        if self.isOpen():
+            self.close()
+
+        return False

--- a/tests/test_cdb2.py
+++ b/tests/test_cdb2.py
@@ -270,3 +270,15 @@ def test_namedtuple_factory_dml():
 
     hndl.execute("delete from simple where 1=1")
     assert next(hndl)._0 == 1
+
+def test_context_manager_support():
+    with cdb2.Handle('mattdb', 'dev') as hndl1:
+        pass
+
+    assert hndl1.isOpen() == False
+
+    with pytest.raises(Exception) as exc_info:
+        with cdb2.Handle('mattdb', 'dev') as hndl2:
+            raise Exception('bad')
+
+    assert hndl2.isOpen() == False

--- a/tests/test_dbapi2.py
+++ b/tests/test_dbapi2.py
@@ -835,3 +835,15 @@ def test_interface_error_reading_result_set_after_commits():
     with pytest.raises(InterfaceError) as exc_info:
         cursor.fetchall()
     assert "No result set exists" in str(exc_info.value)
+
+def test_context_manager_support():
+    with connect('mattdb', 'dev') as hndl1:
+       pass
+
+    assert hndl1.isOpen() == False
+
+    with pytest.raises(Exception) as exc_info:
+        with connect('mattdb', 'dev') as hndl2:
+            raise Exception('bad')
+
+    assert hndl2.isOpen() == False


### PR DESCRIPTION

These changes, when complete, should allow the Python 'with' statement to be used more easily with the comdb2 database providers.