### PR TITLE
Proposal: Rename package to 'comdb2' from 'python-comdb2'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ ccdb2 = Extension("comdb2._ccdb2",
                   sources=["comdb2/_ccdb2.pyx"])
 
 setup(
-    name='python-comdb2',
+    name='comdb2',
     version=__version__,
     author='Alex Chamberlain',
     author_email='achamberlai9@bloomberg.net',


### PR DESCRIPTION
Even if the name of the repository is 'python-comdb2' there is no need
for the name of the Python package to be 'python-comdb2'. Should this be
distributed into a dpkg or anything outside of an 'only-python-packages'
system that package will probably well named 'python-comdb2'.

This package is not yet published into PyPI and any user who has locally
installed via `python setup.py install` will just see his files
overridden with the new package name. The change should be safe.