### PR TITLE
Remove use of cython at setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,13 @@
 import sys
 
 from setuptools import setup, Extension
-from Cython.Build import cythonize
 
 from comdb2 import __version__
 
 ccdb2 = Extension("comdb2._ccdb2",
                   extra_compile_args=['-std=c99'],
                   libraries=['cdb2api', 'protobuf-c'],
-                  sources=["comdb2/_ccdb2.pyx"])
+                  sources=["comdb2/_ccdb2.pyx", "comdb2/_cdb2api.pxd"])
 
 setup(
     name='python-comdb2',
@@ -30,5 +29,5 @@ setup(
     setup_requires=['setuptools>=18.0', 'cython>=0.22'],
     install_requires=["six", "pytz"],
     tests_require=["python-dateutil>=2.6.0", "pytest"],
-    ext_modules=cythonize([ccdb2]),
+    ext_modules=[ccdb2],
 )


### PR DESCRIPTION
comdb2 has a dependency on cython as part of its `setup_requires` but
`setup.py` is importing cython which makes it useless.

Since there is already a requirement for setup_tools >= 18.0 there is
no need to cythonise the code, as setuptools support cython.
It is actually more correct not to do it so the sdist will contain
the source cython files.

setup_tools works the issue around by deferring the use of cython after
the dependencies are resolved and installed.

This is an issue as users willing to install comdb2 need to have
cython already preinstalled in their system (before even the
requirement of setup_requires is read).

SOURCES from the resulting sdist generated after this change:
```
README.md
setup.py                                                                                                                                           
comdb2/__init__.py                                                                                                                                 
comdb2/_ccdb2.pyx                                                                                                                                  
comdb2/_cdb2_types.py
comdb2/_cdb2api.pxd                                                                                                                              
comdb2/cdb2.py                                                                                                                                     
comdb2/dbapi2.py                                                                                                                                   
comdb2/factories.py                                                                                                                                 
```