### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/comdb2/__init__.py
+++ b/comdb2/__init__.py
@@ -28,4 +28,4 @@ anticipate a need to interact with libraries that require DB-API compliant
 connections, this module may be simpler to get started with.
 """
 
-__version__ = "1.1.6"
+__version__ = "1.2.0"


### PR DESCRIPTION
Bump the minor version to reflect that the change to the package name is
backwards incompatible.  Given that this is unlikely to have any real
impact, since the package has never been published to PyPI, don't
increment the major version number.