### PR TITLE
 Use `pyproject.toml` for build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "Cython>=0.29.6",
+    "pkgconfig>=1.4.0",
+    "setuptools>=40.6.0",
+    "wheel",  # Needed for versions of pip not implementing PEP-517
+]
+
+build-backend = 'setuptools.build_meta'

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     author='Alex Chamberlain',
     author_email='achamberlai9@bloomberg.net',
     packages=['comdb2'],
-    setup_requires=['setuptools>=18.0', 'cython>=0.22'],
     install_requires=["six", "pytz"],
     tests_require=["python-dateutil>=2.6.0", "pytest"],
     ext_modules=[ccdb2],


### PR DESCRIPTION
Moving the dependencies here will allow us to install the project without using `easy-install` and allowing us to import `setup.py` without any extra dependency.

Depends on #11