### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/comdb2/__init__.py
+++ b/comdb2/__init__.py
@@ -28,4 +28,4 @@ anticipate a need to interact with libraries that require DB-API compliant
 connections, this module may be simpler to get started with.
 """
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"


### PR DESCRIPTION
As there is no functionality change, just a change on how we build the
sdist and therefore how it will be installed, bump the minor version
only.