### PR TITLE
Add `MANIFEST.in` to include `pyproject.toml`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include pyproject.toml


### PR DESCRIPTION
`setuptools` does not yet include `pyproject.toml` by default, include
it through the `MANIFEST.in` file.

Tested that the sdist includes pyproject.toml manually.