### PR TITLE
Bump version to 1.2.3

### DIFF
--- a/comdb2/_about.py
+++ b/comdb2/_about.py
@@ -1,2 +1,2 @@
 __all__ = ['__version__']
-__version__ = "1.2.2"
+__version__ = "1.2.3"


### PR DESCRIPTION
Bump the patch version for a new release that uses the modern Cython
`@property` decorator rather than the deprecated legacy syntax.