### PR TITLE
setup.py: Drop explicit dependency on protobuf-c

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def make_static_extension(name, **kwargs):
 ccdb2 = make_static_extension(
     "comdb2._ccdb2",
     extra_compile_args=['-std=c99'],
-    libraries=['cdb2api', 'protobuf-c'],
+    libraries=['cdb2api'],
     sources=["comdb2/_ccdb2.pyx", "comdb2/_cdb2api.pxd"]
 )
 


### PR DESCRIPTION
We're meant to only list our direct dependencies here and let pkg-config
sort the rest out; this is a holdover from an earlier iteration when we
listed all dependencies directly.