### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/comdb2/_about.py
+++ b/comdb2/_about.py
@@ -1,2 +1,2 @@
 __all__ = ['__version__']
-__version__ = "1.2.3"
+__version__ = "1.3.0"


### PR DESCRIPTION
This is in preparation for a 1.3.0 release that includes a minor docs
improvement, a fix for SQL statements beginning with comments in
`dbapi2`, and a fix for building on machines where the `protobuf-c`
package is named `libprotobuf-c`.