### PR TITLE
Fix `DatetimeUs.astimezone` Python 3 compatibility

### DIFF
--- a/comdb2/_cdb2_types.py
+++ b/comdb2/_cdb2_types.py
@@ -118,8 +118,8 @@ class DatetimeUs(datetime):
         ret = super(DatetimeUs, cls).fromtimestamp(timestamp, tz)
         return DatetimeUs.fromdatetime(ret)
 
-    def astimezone(self, tz):
-        ret = super(DatetimeUs, self).astimezone(tz)
+    def astimezone(self, *args, **kwargs):
+        ret = super(DatetimeUs, self).astimezone(*args, **kwargs)
         return DatetimeUs.fromdatetime(ret)
 
     def replace(self, *args, **kwargs):


### PR DESCRIPTION
In Python 3, it's legal to call `datetime.datetime.astimezone` with no
arguments, in which case the system's local UTC offset is used for the
returned `datetime.datetime` object. Allow this to work for `DatetimeUs`
as well, by allowing it to be called with any number of arguments, and
forwarding them blindly along to `datetime.datetime` for validation.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>