### PR TITLE
Update to use `root_doc` instead of `master_doc`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,8 +43,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The root toctree document.
+root_doc = 'index'
 
 # General information about the project.
 project = u'Comdb2'


### PR DESCRIPTION
Sphinx 4.0 gives us this option, and allows us to avoid using a divisive
term with negative connotations.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>