### PR TITLE
Fix params type hints

### DIFF
--- a/comdb2/_about.py
+++ b/comdb2/_about.py
@@ -1,2 +1,2 @@
 __all__ = ['__version__']
-__version__ = "1.3.3"
+__version__ = "1.3.4"

--- a/comdb2/cdb2.pyi
+++ b/comdb2/cdb2.pyi
@@ -133,7 +133,7 @@ class Handle:
     def execute(
         self,
         sql: Union[Text, bytes],
-        parameters: Optional[Mapping[Union[Text, bytes], Value]] = ...,
+        parameters: Optional[Mapping[Text, Value]] = ...,
     ) -> Handle: ...
 
     def __iter__(self) -> Iterator[Row]: ...

--- a/comdb2/dbapi2.pyi
+++ b/comdb2/dbapi2.pyi
@@ -176,13 +176,13 @@ class Cursor:
     def execute(
         self,
         sql: Union[str, Text],
-        parameters: Optional[Mapping[Union[str, Text], Value]] = None,
+        parameters: Optional[Mapping[Text, Value]] = None,
     ) -> Cursor: ...
 
     def executemany(
         self,
         sql: str,
-        seq_of_parameters: Sequence[Mapping[Union[str, Text], Value]],
+        seq_of_parameters: Sequence[Mapping[Text, Value]],
     ) -> None: ...
 
     def setinputsizes(self, sizes: Sequence[Any]) -> None: ...


### PR DESCRIPTION
stubs: Type parameter dict's keys as Text

The `Mapping` type is invariant for the key, rather than covariant,
meaning that a `Mapping[Text, int]` isn't considered a subtype of
`Mapping[Union[Text, bytes], int]`, so these annotations were wrong.

To fix them, we'll say that the key must be `Text`.

For the DB-API 2.0 interface this makes no difference whatsoever,
because in Python 3 mode we already only accepted `Text`, and in Python
2 mode mypy accepts a `bytes` where a `Text` was expected.

For the `cdb2` submodule, this means that using `bytes` for the key in
Python 3 won't typecheck cleanly, even though it works. That seems like
a reasonable tradeoff: although it works, we'd prefer users use `str`
keys, so the warning if they don't seems reasonable.

Signed-off-by: Matt Wozniski <mwozniski@bloomberg.net>
