### PR TITLE
Enable CI on Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,15 @@ jobs:
             fi;
           done
         '
+      - name: Creating tables
+        run: |
+          tables="$(cat tests/schemas/$COMDB2_DBNAME/table_constraint_order.txt)"
+          for table_name in $tables
+          do
+            table_file="tests/schemas/$COMDB2_DBNAME/$table_name.csc2"
+            echo "Creating $table_name from $table_file"
+            /opt/bb/bin/cdb2sql "$COMDB2_DBNAME" local "create table $table_name { $(cat $table_file) }"
+          done
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4 # note that this step overwrites the PKG_CONFIG_PATH variable
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,94 @@
+name: Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+env:
+  COMDB2_DBNAME: mattdb
+  TIMEOUT: 30
+jobs:
+  test:
+    name: Test suite
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - '3.10'
+          - '3.9'
+          - '3.8'
+          - '3.7'
+          - '3.6'
+          - '2.7'
+    steps:
+      - name: Install dependencies
+        run: '
+          sudo apt-get install -qy
+            pkg-config
+        ' # libcdb2api-dev is installed from source below
+      - uses: actions/checkout@v3
+      - name: Checkout comdb2 dependency
+        uses: actions/checkout@v3
+        with:
+          repository: bloomberg/comdb2
+          path: original_comdb2
+      - name: Build comdb2 from source
+        run: '
+          sudo apt-get update &&
+          sudo apt-get install -qy
+            bison
+            build-essential
+            cmake
+            flex
+            libevent-dev
+            liblz4-dev
+            libprotobuf-c-dev
+            libreadline-dev
+            libsqlite3-dev
+            libssl-dev
+            libunwind-dev
+            ncurses-dev
+            protobuf-c-compiler
+            tcl
+            uuid-dev
+            zlib1g-dev &&
+          (
+            mkdir original_comdb2/build &&
+            cd original_comdb2/build &&
+            cmake .. &&
+            make &&
+            sudo make install
+          )
+        '
+      - name: Start local comdb2 instance
+        run: '
+          sudo mkdir -p /opt/bb/share/schemas/$COMDB2_DBNAME &&
+          echo "$COMDB2_DBNAME 1234 $(hostname -f)" > /opt/bb/etc/cdb2/config/comdb2db.cfg &&
+          (/opt/bb/bin/pmux -n &) &&
+          echo started pmux &&
+          /opt/bb/bin/comdb2 --create $COMDB2_DBNAME &&
+          (/opt/bb/bin/comdb2 $COMDB2_DBNAME > /tmp/$COMDB2_DBNAME.log 2>&1 &);
+          iterations=0;
+          until /opt/bb/bin/cdb2sql $COMDB2_DBNAME local "select 1+1" > /dev/null 2>&1;
+          do
+            echo -n ".";
+            sleep 1;
+            iterations=$(($iterations + 1));
+            if [ "$iterations" -ge "$TIMEOUT" ]; then
+              echo >&2 "$COMDB2_DBNAME failed to start after $iterations seconds";
+              exit 1;
+            fi;
+          done
+        '
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4 # note that this step overwrites the PKG_CONFIG_PATH variable
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          PKG_CONFIG_PATH=/opt/bb/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig LDFLAGS="-Wl,-rpath,/opt/bb/lib" python -m pip install .[tests]
+      - name: Run Tests
+        run: (cd tests && python -m pytest -vvv)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@ requires = [
 ]
 
 build-backend = 'setuptools.build_meta'
+
+[tool.pytest.ini_options]
+xfail_strict=true

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     author_email='achamberlai9@bloomberg.net',
     packages=['comdb2'],
     install_requires=["six", "pytz"],
-    extras_require={"tests": ["python-dateutil>=2.6.0", "pytest"]},
+    extras_require={"tests": ["python-dateutil>=2.6.0", "pytest", "mock; python_version < '3.3'"]},
     ext_modules=[ccdb2],
     package_data={"comdb2": ["py.typed", "*.pyi"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     author_email='achamberlai9@bloomberg.net',
     packages=['comdb2'],
     install_requires=["six", "pytz"],
-    tests_require=["python-dateutil>=2.6.0", "pytest"],
+    extras_require={"tests": ["python-dateutil>=2.6.0", "pytest"]},
     ext_modules=[ccdb2],
     package_data={"comdb2": ["py.typed", "*.pyi"]},
 )

--- a/tests/schemas/mattdb/all_datatypes.csc2
+++ b/tests/schemas/mattdb/all_datatypes.csc2
@@ -1,0 +1,30 @@
+tag ondisk
+{
+    short         short_col
+    u_short       u_short_col
+    int           int_col
+    u_int         u_int_col
+    longlong      longlong_col
+//  u_longlong    u_longlong_col
+    float         float_col
+    double        double_col
+    byte          byte_col
+    byte          byte_array_col[5]
+    cstring       cstring_col[6]
+    pstring       pstring_col[10]
+    blob          blob_col
+    datetime      datetime_col
+//  datetimeus    datetimeus_col
+//  intervalym    intervalym_col
+//  intervalds    intervalds_col
+//  intervaldsus  intervaldsus_col
+    vutf8         vutf8_col
+//  decimal32     decimal32_col
+//  decimal64     decimal64_col
+//  decimal128    decimal128_col
+}
+
+keys
+{
+    "KEY1" = short_col
+}

--- a/tests/schemas/mattdb/child.csc2
+++ b/tests/schemas/mattdb/child.csc2
@@ -1,0 +1,14 @@
+tag ondisk
+{
+    int  key
+}
+
+keys
+{
+    "KEY" = key
+}
+
+constraints
+{
+    "KEY" -> <"simple":"KEY1">
+}

--- a/tests/schemas/mattdb/simple.csc2
+++ b/tests/schemas/mattdb/simple.csc2
@@ -1,0 +1,10 @@
+tag ondisk
+{
+    int  key
+    int  val
+}
+
+keys
+{
+    "KEY1" = key
+}

--- a/tests/schemas/mattdb/strings.csc2
+++ b/tests/schemas/mattdb/strings.csc2
@@ -1,0 +1,5 @@
+tag ondisk
+{
+    cstring  foo[6]
+    byte     bar[5]
+}

--- a/tests/schemas/mattdb/table_constraint_order.txt
+++ b/tests/schemas/mattdb/table_constraint_order.txt
@@ -1,0 +1,4 @@
+all_datatypes
+simple
+strings
+child

--- a/tests/test_cdb2.py
+++ b/tests/test_cdb2.py
@@ -219,6 +219,7 @@ def test_get_effects():
     assert hndl.get_effects().num_deleted == 1
 
 
+@pytest.mark.xfail(reason="cdb2_open ignores tier")
 def test_nonascii_error_messages():
     with pytest.raises(cdb2.Error) as exc_info:
         cdb2.Handle('mattdb', b'\xc3')

--- a/tests/test_dbapi2.py
+++ b/tests/test_dbapi2.py
@@ -77,6 +77,7 @@ def delete_all_rows():
     conn.close()
 
 
+@pytest.mark.xfail(reason="cdb2_open ignores tier")
 def test_invalid_cluster():
     with pytest.raises(OperationalError):
         connect('mattdb', 'foo')


### PR DESCRIPTION
Fixes #37

2 of the 95 tests do not pass because `cdb2_open` seems to completly ignore its third argument (and that is considered a bug by the maintainers of bloomberg/comdb2). These tests are not considered critical and thus we will be skipping them for now, while the people maintaining comdb2 find a solution on how to fix it.

**Describe your changes**
Use Github Actions to run the tests automatically for every PR.

**Testing performed**
The tests are being run on Github Actions for this very PR.

**Additional context**

Note that https://github.com/bloomberg/comdb2/pull/3355 and https://github.com/bloomberg/comdb2/pull/3362 were merged specifically to enable this PR.