### PR TITLE
Use `libcdb2api.a` instead of `libcdb2api.so`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,8 +136,9 @@ jobs:
             libunwind-dev
             zlib1g-dev &&
           tar xvf bloomberg-comdb2.tar.gz &&
-          (cd bloomberg-comdb2/build && sudo make install)
-        '
+          (cd bloomberg-comdb2/build && sudo make install) &&
+          sudo rm /opt/bb/lib/libcdb2api.so
+        '  # removing the `.so` to instead pick `libcdb2api.a`
       - name: Start local comdb2 instance
         run: '
           sudo mkdir -p /opt/bb/share/schemas/$COMDB2_DBNAME &&


### PR DESCRIPTION
This will make it easier if and when we decide to publish wheels, and
will also fix our CI by ensuring that (almost) all dependencies are
built statically within `_ccdb2.so`.

Signed-off-by: Gus Monod <gmonod1@bloomberg.net>
