### PR TITLE
Drop 2.7 support

### DIFF
--- a/comdb2/__init__.py
+++ b/comdb2/__init__.py
@@ -12,7 +12,7 @@
 """This package provides Python interfaces to Comdb2 databases.
 
 Two different Python submodules are provided for interacting with Comdb2
-databases.  Both submodules work from Python 2.7+ and from Python 3.5+.
+databases.  Both submodules work from Python 3.6.
 
 `comdb2.dbapi2` provides an interface that conforms to `the Python Database API
 Specification v2.0 <https://www.python.org/dev/peps/pep-0249/>`_.  If you're

--- a/comdb2/_about.py
+++ b/comdb2/_about.py
@@ -1,2 +1,2 @@
 __all__ = ['__version__']
-__version__ = "1.4.1"
+__version__ = "1.5.0"

--- a/comdb2/_ccdb2.pyx
+++ b/comdb2/_ccdb2.pyx
@@ -22,7 +22,6 @@ from cpython.mem cimport PyMem_Malloc, PyMem_Free
 import datetime
 
 from pytz import timezone, UTC
-import six
 
 from ._cdb2_types import Error, Effects, DatetimeUs
 from . cimport _cdb2api as lib
@@ -113,7 +112,7 @@ cdef class _ParameterValue(object):
                 self.size = 0
                 self.data = NULL
                 return
-            elif isinstance(obj, six.integer_types):
+            elif isinstance(obj, int):
                 self.type = lib.CDB2_INTEGER
                 self.owner = None
                 self.size = sizeof(long long)
@@ -167,7 +166,7 @@ cdef class _ParameterValue(object):
                 param_name,
                 exc_desc,
             )
-            six.raise_from(Error(lib.CDB2ERR_CONV_FAIL, errmsg), exc)
+            raise Error(lib.CDB2ERR_CONV_FAIL, errmsg) from exc
         else:
             errmsg = "Can't map %s value %r for parameter '%s' to a Comdb2 type" % (
                 type(obj).__name__,
@@ -248,7 +247,7 @@ cdef _column_value(lib.cdb2_hndl_tp *hndl, int col):
 
     if exc is not None:
         errmsg += _describe_exception(exc)
-        six.raise_from(Error(lib.CDB2ERR_CONV_FAIL, errmsg), exc)
+        raise Error(lib.CDB2ERR_CONV_FAIL, errmsg) from exc
     else:
         errmsg += "Unsupported column type"
         raise Error(lib.CDB2ERR_NOTSUPPORTED, errmsg)
@@ -289,7 +288,7 @@ cdef class _Cursor(object):
                 ret = self.row_class(ret)
             except Exception as e:
                 errmsg = "Instantiating row failed: " + _describe_exception(e)
-                six.raise_from(Error(lib.CDB2ERR_UNKNOWN, errmsg), e)
+                raise Error(lib.CDB2ERR_UNKNOWN, errmsg) from e
         return ret
 
 
@@ -393,7 +392,7 @@ cdef class Handle(object):
                 row_class = self._row_factory(self.column_names())
             except Exception as e:
                 errmsg = "row_factory call failed: " + _describe_exception(e)
-                six.raise_from(Error(lib.CDB2ERR_UNKNOWN, errmsg), e)
+                raise Error(lib.CDB2ERR_UNKNOWN, errmsg) from e
 
         cdef _Cursor ret = _Cursor.__new__(_Cursor)
         ret.handle = self

--- a/comdb2/_cdb2_types.py
+++ b/comdb2/_cdb2_types.py
@@ -36,11 +36,11 @@ class Error(RuntimeError):
             after the failed call.
     """
     def __init__(self, error_code, error_message):
-        if not(isinstance(error_message, six.text_type)):
+        if not(isinstance(error_message, str)):
             error_message = _errstr(error_message)
         self.error_code = error_code
         self.error_message = error_message
-        super(Error, self).__init__(error_code, error_message)
+        super().__init__(error_code, error_message)
 
 
 class Effects(namedtuple('Effects',
@@ -94,13 +94,13 @@ class DatetimeUs(datetime):
                           dt.tzinfo, **kwargs)
 
     def __add__(self, other):
-        ret = super(DatetimeUs, self).__add__(other)
+        ret = super().__add__(other)
         if isinstance(ret, datetime):
             return DatetimeUs.fromdatetime(ret)
         return ret  # must be a timedelta
 
     def __sub__(self, other):
-        ret = super(DatetimeUs, self).__sub__(other)
+        ret = super().__sub__(other)
         if isinstance(ret, datetime):
             return DatetimeUs.fromdatetime(ret)
         return ret  # must be a timedelta
@@ -110,20 +110,20 @@ class DatetimeUs(datetime):
 
     @classmethod
     def now(cls, tz=None):
-        ret = super(DatetimeUs, cls).now(tz)
+        ret = super().now(tz)
         return DatetimeUs.fromdatetime(ret)
 
     @classmethod
     def fromtimestamp(cls, timestamp, tz=None):
-        ret = super(DatetimeUs, cls).fromtimestamp(timestamp, tz)
+        ret = super().fromtimestamp(timestamp, tz)
         return DatetimeUs.fromdatetime(ret)
 
     def astimezone(self, *args, **kwargs):
-        ret = super(DatetimeUs, self).astimezone(*args, **kwargs)
+        ret = super().astimezone(*args, **kwargs)
         return DatetimeUs.fromdatetime(ret)
 
     def replace(self, *args, **kwargs):
         # Before Python 3.7, it is effectively implementation dependent whether
         # this returns a DatetimeUs or a datetime.
-        dt = super(DatetimeUs, self).replace(*args, **kwargs)
+        dt = super().replace(*args, **kwargs)
         return self.fromdatetime(dt)

--- a/comdb2/_cdb2_types.py
+++ b/comdb2/_cdb2_types.py
@@ -11,7 +11,6 @@
 
 from collections import namedtuple
 from datetime import datetime
-import six
 
 __name__ = 'comdb2.cdb2'
 

--- a/comdb2/cdb2.py
+++ b/comdb2/cdb2.py
@@ -127,7 +127,6 @@ Note:
     problems for new users.
     Make sure to carefully read :ref:`String and Blob Types` on that page.
 """
-from __future__ import absolute_import, unicode_literals
 
 from ._cdb2_types import Error, Effects, DatetimeUs
 from ._ccdb2 import Handle as CHandle
@@ -136,40 +135,40 @@ __all__ = ['Error', 'Handle', 'Effects', 'DatetimeUs',
            'ERROR_CODE', 'TYPE', 'HANDLE_FLAGS']
 
 # Pull all comdb2 error codes from cdb2api.h into our namespace
-ERROR_CODE = {u'CONNECT_ERROR'         : -1,
-              u'NOTCONNECTED'          : -2,
-              u'PREPARE_ERROR'         : -3,
-              u'IO_ERROR'              : -4,
-              u'INTERNAL'              : -5,
-              u'NOSTATEMENT'           : -6,
-              u'BADCOLUMN'             : -7,
-              u'BADSTATE'              : -8,
-              u'ASYNCERR'              : -9,
-              u'INVALID_ID'            : -12,
-              u'RECORD_OUT_OF_RANGE'   : -13,
-              u'REJECTED'              : -15,
-              u'STOPPED'               : -16,
-              u'BADREQ'                : -17,
-              u'DBCREATE_FAILED'       : -18,
-              u'THREADPOOL_INTERNAL'   : -20,
-              u'READONLY'              : -21,
-              u'NOMASTER'              : -101,
-              u'UNTAGGED_DATABASE'     : -102,
-              u'CONSTRAINTS'           : -103,
-              u'DEADLOCK'              : 203,
-              u'TRAN_IO_ERROR'         : -105,
-              u'ACCESS'                : -106,
-              u'TRAN_MODE_UNSUPPORTED' : -107,
-              u'VERIFY_ERROR'          : 2,
-              u'FKEY_VIOLATION'        : 3,
-              u'NULL_CONSTRAINT'       : 4,
-              u'CONV_FAIL'             : 113,
-              u'NONKLESS'              : 114,
-              u'MALLOC'                : 115,
-              u'NOTSUPPORTED'          : 116,
-              u'DUPLICATE'             : 299,
-              u'TZNAME_FAIL'           : 401,
-              u'UNKNOWN'               : 300,
+ERROR_CODE = {'CONNECT_ERROR'         : -1,
+              'NOTCONNECTED'          : -2,
+              'PREPARE_ERROR'         : -3,
+              'IO_ERROR'              : -4,
+              'INTERNAL'              : -5,
+              'NOSTATEMENT'           : -6,
+              'BADCOLUMN'             : -7,
+              'BADSTATE'              : -8,
+              'ASYNCERR'              : -9,
+              'INVALID_ID'            : -12,
+              'RECORD_OUT_OF_RANGE'   : -13,
+              'REJECTED'              : -15,
+              'STOPPED'               : -16,
+              'BADREQ'                : -17,
+              'DBCREATE_FAILED'       : -18,
+              'THREADPOOL_INTERNAL'   : -20,
+              'READONLY'              : -21,
+              'NOMASTER'              : -101,
+              'UNTAGGED_DATABASE'     : -102,
+              'CONSTRAINTS'           : -103,
+              'DEADLOCK'              : 203,
+              'TRAN_IO_ERROR'         : -105,
+              'ACCESS'                : -106,
+              'TRAN_MODE_UNSUPPORTED' : -107,
+              'VERIFY_ERROR'          : 2,
+              'FKEY_VIOLATION'        : 3,
+              'NULL_CONSTRAINT'       : 4,
+              'CONV_FAIL'             : 113,
+              'NONKLESS'              : 114,
+              'MALLOC'                : 115,
+              'NOTSUPPORTED'          : 116,
+              'DUPLICATE'             : 299,
+              'TZNAME_FAIL'           : 401,
+              'UNKNOWN'               : 300,
              }
 """This dict maps all known Comdb2 error names to their respective values.
 
@@ -180,15 +179,15 @@ time.
 """
 
 # Pull comdb2 column types from cdb2api.h into our namespace
-TYPE = {u'INTEGER'      : 1,
-        u'REAL'         : 2,
-        u'CSTRING'      : 3,
-        u'BLOB'         : 4,
-        u'DATETIME'     : 6,
-        u'INTERVALYM'   : 7,
-        u'INTERVALDS'   : 8,
-        u'DATETIMEUS'   : 9,
-        u'INTERVALDSUS' : 10,
+TYPE = {'INTEGER'      : 1,
+        'REAL'         : 2,
+        'CSTRING'      : 3,
+        'BLOB'         : 4,
+        'DATETIME'     : 6,
+        'INTERVALYM'   : 7,
+        'INTERVALDS'   : 8,
+        'DATETIMEUS'   : 9,
+        'INTERVALDSUS' : 10,
        }
 """This dict maps all known Comdb2 types to their enumeration value.
 
@@ -198,11 +197,11 @@ guaranteed because new types can be added to the Comdb2 server at any time.
 """
 
 # Pull comdb2 handle flags from cdb2api.h into our namespace
-HANDLE_FLAGS = {u'READ_INTRANS_RESULTS' : 2,
-                u'DIRECT_CPU'           : 4,
-                u'RANDOM'               : 8,
-                u'RANDOMROOM'           : 16,
-                u'ROOM'                 : 32,
+HANDLE_FLAGS = {'READ_INTRANS_RESULTS' : 2,
+                'DIRECT_CPU'           : 4,
+                'RANDOM'               : 8,
+                'RANDOMROOM'           : 16,
+                'ROOM'                 : 32,
                }
 """This dict maps all known Comdb2 flags to their enumeration value.
 
@@ -211,7 +210,7 @@ can be passed as well (such as the bitwise OR of two different flags).
 """
 
 
-class Handle(object):
+class Handle:
     """Represents a connection to a database.
 
     By default, the connection will be made to the cluster configured as the

--- a/comdb2/cdb2.py
+++ b/comdb2/cdb2.py
@@ -112,8 +112,8 @@ SQL type       Python type
 NULL           ``None``
 integer        `int`
 real           `float`
-blob           `six.binary_type` (aka `bytes` in Python 3, ``str`` in Python 2)
-text           `six.text_type` (aka `str` in Python 3, ``unicode`` in Python 2)
+blob           `bytes`
+text           `str`
 datetime       `datetime.datetime`
 datetimeus     `DatetimeUs`
 ============   ================================================================

--- a/comdb2/dbapi2.py
+++ b/comdb2/dbapi2.py
@@ -138,8 +138,8 @@ SQL type       Python type
 NULL           ``None``
 integer        `int`
 real           `float`
-blob           `six.binary_type` (aka `bytes` in Python 3, ``str`` in Python 2)
-text           `six.text_type` (aka `str` in Python 3, ``unicode`` in Python 2)
+blob           `bytes`
+text           `str`
 datetime       `datetime.datetime`
 datetimeus     `DatetimeUs`
 ============   ================================================================
@@ -245,7 +245,6 @@ import itertools
 import weakref
 import datetime
 import re
-import six
 
 from . import cdb2
 
@@ -297,7 +296,7 @@ _FIRST_WORD_OF_STMT = re.compile(
     \s*           # then skip over any whitespace
     (\w+)         # and capture the first word
     """,
-    re.VERBOSE | re.DOTALL | (0 if six.PY2 else re.ASCII),
+    re.VERBOSE | re.DOTALL | re.ASCII,
 )
 _VALID_SP_NAME = re.compile(r'^[A-Za-z0-9_.]+$')
 
@@ -349,10 +348,7 @@ DatetimeUsFromTicks = DatetimeUs.fromtimestamp
 TimestampFromTicks = Timestamp.fromtimestamp
 TimestampUsFromTicks = TimestampUs.fromtimestamp
 
-try:
-    UserException = StandardError  # Python 2
-except NameError:
-    UserException = Exception      # Python 3
+UserException = Exception
 
 
 class Error(UserException):

--- a/comdb2/factories.py
+++ b/comdb2/factories.py
@@ -21,7 +21,6 @@ a `collections.namedtuple` by using `namedtuple_row_factory` as the
 A factory function will be called with a list of column names, and must return
 a callable that will be called once per row with a list of column values.
 """
-from __future__ import unicode_literals
 from collections import namedtuple
 from collections import Counter
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -261,8 +261,7 @@ htmlhelp_basename = 'Comdb2doc'
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
-                       'six': ('https://six.readthedocs.io', None)}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # Don't highlight the code for the Python standard library datetime module.
 viewcode_import = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Comdb2 documentation build configuration file, created by
 # sphinx-quickstart on Thu Sep  8 16:16:10 2016.
@@ -47,8 +46,8 @@ source_suffix = '.rst'
 root_doc = 'index'
 
 # General information about the project.
-project = u'Comdb2'
-copyright = u'2017, Bloomberg LP'
+project = 'Comdb2'
+copyright = '2017, Bloomberg LP'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/dbapi2.rst
+++ b/docs/dbapi2.rst
@@ -87,9 +87,9 @@ them if you so choose, but you are not required to.
 
     Creates an object suitable for binding as a BLOB parameter.
 
-    If the input argument was a `six.text_type` Unicode string, it is
-    encoded as a UTF-8 byte string and returned.  Otherwise, the input
-    argument is passed to the `bytes` constructor, and the result returned.
+    If the input argument was a `str` object, it is encoded as a UTF-8 byte
+    string and returned.  Otherwise, the input argument is passed to the
+    `bytes` constructor, and the result returned.
 
     :param string: A string from which the new object is constructed
     :rtype: `bytes`

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -2,10 +2,9 @@
 Best Practices, Tips, and Tricks
 ********************************
 
-#. This package uses `six.text_type` for text and `bytes` for blobs; this may
-   be surprising if you're using `str` in Python 2.  See :doc:`types` for an
-   explanation of what Python types must be used when binding parameters, and
-   what Python types will be returned for result columns.
+#. This package uses `str` for text and `bytes` for blobs. See :doc:`types` for
+   an explanation of what Python types must be used when binding parameters,
+   and what Python types will be returned for result columns.
 
    An error message saying "incompatible values from SQL blob of length 3 to
    bcstring field 'foo'" most likely means that you passed a byte string where
@@ -24,11 +23,8 @@ Best Practices, Tips, and Tricks
    a ``WHERE`` clause that you expected to match some rows will silently fail
    to match any.
 
-#. Prefer using Python 3 rather than Python 2 when possible.  The above type
-   mappings are much more intuitive in Python 3 than in Python 2.  If you can't
-   use Python 3 but are writing a new module, prefer to use ``from __future__
-   import unicode_literals`` to opt into forward compatible unicode string
-   literals (rather than the default, string literals as byte strings).
+#. The latest version of this package only supports Python 3. If you can't
+   use Python 3, make sure to use version 1.4.1 or earlier.
 
 #. The database can time out connections that have been idle for a period of
    time, and each idle connection uses some amount of resources on the database

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -24,7 +24,7 @@ Best Practices, Tips, and Tricks
    to match any.
 
 #. The latest version of this package only supports Python 3. If you can't
-   use Python 3, make sure to use version 1.4.1 or earlier.
+   use Python 3, make sure to use version less than ``1.5.0``.
 
 #. The database can time out connections that have been idle for a period of
    time, and each idle connection uses some amount of resources on the database

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -42,23 +42,11 @@ into a column of type ``short``), an exception will be raised.
 String and Blob Types
 =====================
 
-This module uses byte strings to represent BLOB values, and Unicode strings to
-represent TEXT columns.  This was chosen for maximum forward compatibility with
-Python 3, and to make it easier to write code that will work identically in
-both languages.  This decision has many important ramifications.
+You may occasionally need to convert between byte strings and Unicode strings:
 
 #.  If you have a variable of type `bytes` and you want to pass it to the
     database as a TEXT value, you need to convert it to a `str` using
     `~bytes.decode`.
-
-#.  TEXT columns are returned to you as `str` strings. If you need to pass them
-    to a library that expects `bytes` strings, you have to use `~str.encode`,
-    like this::
-
-        cursor.execute("select col from tbl")
-        for row in cursor:
-            col = row[0]
-            library_func(col.encode('utf-8'))
 
 #.  When a TEXT column is read back from the database, it is decoded as UTF-8.
     If your database has non-UTF-8 text in a ``cstring`` column, you need to

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(
     author_email='achamberlai9@bloomberg.net',
     packages=['comdb2'],
     install_requires=["six", "pytz"],
-    extras_require={"tests": ["python-dateutil>=2.6.0", "pytest", "mock; python_version < '3.3'"]},
+    extras_require={"tests": ["python-dateutil>=2.6.0", "pytest"]},
+    python_requires=">=3.6",
     ext_modules=[ccdb2],
     package_data={"comdb2": ["py.typed", "*.pyi"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     author='Alex Chamberlain',
     author_email='achamberlai9@bloomberg.net',
     packages=['comdb2'],
-    install_requires=["six", "pytz"],
+    install_requires=["pytz"],
     extras_require={"tests": ["python-dateutil>=2.6.0", "pytest"]},
     python_requires=">=3.6",
     ext_modules=[ccdb2],

--- a/tests/test_cdb2.py
+++ b/tests/test_cdb2.py
@@ -14,7 +14,6 @@ from comdb2 import cdb2
 from comdb2.factories import dict_row_factory
 from comdb2.factories import namedtuple_row_factory
 import pytest
-import six
 
 COLUMN_LIST = ("short_col u_short_col int_col u_int_col longlong_col"
                " float_col double_col byte_col byte_array_col"

--- a/tests/test_cdb2.py
+++ b/tests/test_cdb2.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import unicode_literals, absolute_import
 
 from comdb2 import cdb2
 from comdb2.factories import dict_row_factory
@@ -153,12 +152,12 @@ def test_row_factories_with_dup_col_names():
     hndl.row_factory = namedtuple_row_factory
     with pytest.raises(cdb2.Error) as exc_info:
         hndl.execute(query)
-    assert isinstance(exc_info.value.args[1], six.text_type)
+    assert isinstance(exc_info.value.args[1], str)
 
     hndl.row_factory = dict_row_factory
     with pytest.raises(cdb2.Error) as exc_info:
         hndl.execute(query)
-    assert isinstance(exc_info.value.args[1], six.text_type)
+    assert isinstance(exc_info.value.args[1], str)
 
 
 def test_setting_non_callable_row_factory():
@@ -193,7 +192,7 @@ def test_failures_instantiating_row_class():
     it = iter(hndl.execute(query))
     with pytest.raises(cdb2.Error) as exc_info:
         next(it)
-    assert isinstance(exc_info.value.args[1], six.text_type)
+    assert isinstance(exc_info.value.args[1], str)
 
 
 def test_get_effects():

--- a/tests/test_cdb2_datetimeus.py
+++ b/tests/test_cdb2_datetimeus.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import unicode_literals, absolute_import
 
 from comdb2 import cdb2
 import pytz

--- a/tests/test_dbapi2.py
+++ b/tests/test_dbapi2.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import unicode_literals, absolute_import
 
 from comdb2.dbapi2 import _sql_operation
 from comdb2.dbapi2 import NUMBER
@@ -43,7 +42,7 @@ from functools import partial
 try:
     from unittest.mock import patch
 except ImportError:
-    from mock import patch
+    from unittest.mock import patch
 
 COLUMN_LIST = ("short_col u_short_col int_col u_int_col longlong_col"
                " float_col double_col byte_col byte_array_col"
@@ -618,7 +617,7 @@ def test_exceptions_containing_unicode_error_messages():
         try:
             cursor.execute("select")
         except ProgrammingError as exc:
-            assert isinstance(exc.args[0], six.text_type)
+            assert isinstance(exc.args[0], str)
             raise
 
 

--- a/tests/test_dbapi2.py
+++ b/tests/test_dbapi2.py
@@ -36,7 +36,6 @@ from comdb2.factories import namedtuple_row_factory
 import pytest
 import datetime
 import pytz
-import six
 from functools import partial
 
 try:

--- a/tests/test_dbapi2.py
+++ b/tests/test_dbapi2.py
@@ -38,10 +38,7 @@ import datetime
 import pytz
 from functools import partial
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from unittest.mock import patch
+from unittest.mock import patch
 
 COLUMN_LIST = ("short_col u_short_col int_col u_int_col longlong_col"
                " float_col double_col byte_col byte_array_col"


### PR DESCRIPTION
Drop support for 2.7, and bump version to be `1.5.0`, the first version that explicitly supports 3.6+