### PR TITLE
Drop support for 3.6

### DIFF
--- a/comdb2/__init__.py
+++ b/comdb2/__init__.py
@@ -12,7 +12,7 @@
 """This package provides Python interfaces to Comdb2 databases.
 
 Two different Python submodules are provided for interacting with Comdb2
-databases.  Both submodules work from Python 3.6.
+databases.
 
 `comdb2.dbapi2` provides an interface that conforms to `the Python Database API
 Specification v2.0 <https://www.python.org/dev/peps/pep-0249/>`_.  If you're

--- a/comdb2/_about.py
+++ b/comdb2/_about.py
@@ -1,2 +1,2 @@
 __all__ = ['__version__']
-__version__ = "1.5.0"
+__version__ = "1.6.0"

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     packages=['comdb2'],
     install_requires=["pytz"],
     extras_require={"tests": ["python-dateutil>=2.6.0", "pytest"]},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     ext_modules=[ccdb2],
     package_data={"comdb2": ["py.typed", "*.pyi"]},
 )


### PR DESCRIPTION
Change `python_requires` to make it explicit that this version only
supports 3.7+ and bump the minor version.

Note that `pyupgrade --py37-plus` is a no-op.

Signed-off-by: Gus Monod <gmonod1@bloomberg.net>
