### PR TITLE
tests: Fix a test that fails on leap days

### DIFF
--- a/tests/test_cdb2_datetimeus.py
+++ b/tests/test_cdb2_datetimeus.py
@@ -114,7 +114,7 @@ def test_datetimeus_type_stickiness():
     check(cdb2.DatetimeUs.now() - datetime.timedelta(0))
     check(cdb2.DatetimeUs.now() + datetime.timedelta(0))
     check(datetime.timedelta(0) + cdb2.DatetimeUs.now())
-    check(cdb2.DatetimeUs.now().replace(year=2015))
+    check(cdb2.DatetimeUs.now().replace(year=2016))
     check(cdb2.DatetimeUs.now().replace(tzinfo=new_york))
     check(cdb2.DatetimeUs.now(utc).astimezone(new_york))
 


### PR DESCRIPTION
This test takes the current date and time and switches the year to a hardcoded one. On leap day, that fails because the hardcoded year didn't have a February 29th. Update the test to use a hardcoded year that did.