### PR TITLE
ci: Explicitly remove Comdb2 build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,8 @@ jobs:
             libunwind-dev
             zlib1g-dev &&
           tar xvf bloomberg-comdb2.tar.gz &&
-          (cd bloomberg-comdb2/build && sudo make install)
+          (cd bloomberg-comdb2/build && sudo make install) &&
+          sudo rm -rf bloomberg-comdb2/ bloomberg-comdb2.tar.gz
         '
       - uses: actions/checkout@v4
       - name: 'Set up Python 3.7'
@@ -136,7 +137,8 @@ jobs:
             libunwind-dev
             zlib1g-dev &&
           tar xvf bloomberg-comdb2.tar.gz &&
-          (cd bloomberg-comdb2/build && sudo make install)
+          (cd bloomberg-comdb2/build && sudo make install) &&
+          sudo rm -rf bloomberg-comdb2/ bloomberg-comdb2.tar.gz
         '
       - name: Start local comdb2 instance
         run: '


### PR DESCRIPTION
actions/checkout@v4 is getting a "permission denied" error when attempting to remove some of these files. Remove them ourselves as a super-user.
