### PR TITLE
Update `upload-artifact` and `download-artifact`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Archive bloomberg-comdb2 repo with build artifacts
         run: 'tar czvf bloomberg-comdb2.tar.gz bloomberg-comdb2/'
       - name: Upload bloomberg-comdb2 repo with build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bloomberg-comdb2
           path: ./bloomberg-comdb2.tar.gz
@@ -72,7 +72,7 @@ jobs:
     needs: [build_bloomberg_comdb2]
     steps:
       - name: Download bloomberg-comdb2 with build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bloomberg-comdb2
           path: .
@@ -102,7 +102,7 @@ jobs:
           pipx run build --sdist
         '
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-comdb2-sdist
           path: dist/*.tar.gz
@@ -123,7 +123,7 @@ jobs:
           - '3.7'
     steps:
       - name: Download comdb2 repo with build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bloomberg-comdb2
           path: .
@@ -162,7 +162,7 @@ jobs:
           done
         '
       - name: Download python-comdb2 sdist
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-comdb2-sdist
           path: dist


### PR DESCRIPTION
The latest version of each is v4, and v3 is deprecated and scheduled to be decommissioned.