### PR TITLE
Handle C++ exceptions thrown within `libcdb2api`

### DIFF
--- a/comdb2/_about.py
+++ b/comdb2/_about.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.7.0"
+__version__ = "1.7.1"

--- a/comdb2/_cdb2api.pxd
+++ b/comdb2/_cdb2api.pxd
@@ -63,19 +63,19 @@ cdef extern from "cdb2api.h" nogil:
     ctypedef struct cdb2_hndl_tp:
         pass
 
-    int cdb2_open(cdb2_hndl_tp **hndl, const char *dbname, const char *type, int flags);
-    int cdb2_next_record(cdb2_hndl_tp *hndl);
-    int cdb2_get_effects(cdb2_hndl_tp *hndl, cdb2_effects_tp *effects);
-    int cdb2_close(cdb2_hndl_tp* hndl);
-    int cdb2_run_statement(cdb2_hndl_tp *hndl, const char *sql);
-    int cdb2_run_statement_typed(cdb2_hndl_tp *hndl, const char *sql, int num_types, int *types);
-    int cdb2_numcolumns(cdb2_hndl_tp* hndl);
-    const char* cdb2_column_name(cdb2_hndl_tp* hndl, int col);
-    int cdb2_column_type(cdb2_hndl_tp* hndl, int col);
-    int cdb2_column_size(cdb2_hndl_tp* hndl, int col);
-    void* cdb2_column_value(cdb2_hndl_tp* hndl, int col);
-    const char* cdb2_errstr(cdb2_hndl_tp* hndl);
-    int cdb2_bind_param(cdb2_hndl_tp *hndl, const char *name, int type, const void *varaddr, int length);
-    int cdb2_bind_array(cdb2_hndl_tp *hndl, const char *name, cdb2_coltype, const void *varaddr, size_t count, size_t typelen);
-    int cdb2_clearbindings(cdb2_hndl_tp *hndl);
-    int cdb2_clear_ack(cdb2_hndl_tp *hndl);
+    int cdb2_open(cdb2_hndl_tp **hndl, const char *dbname, const char *type, int flags) except +
+    int cdb2_next_record(cdb2_hndl_tp *hndl) except +
+    int cdb2_get_effects(cdb2_hndl_tp *hndl, cdb2_effects_tp *effects) except +
+    int cdb2_close(cdb2_hndl_tp* hndl) except +
+    int cdb2_run_statement(cdb2_hndl_tp *hndl, const char *sql) except +
+    int cdb2_run_statement_typed(cdb2_hndl_tp *hndl, const char *sql, int num_types, int *types) except +
+    int cdb2_numcolumns(cdb2_hndl_tp* hndl) except +
+    const char* cdb2_column_name(cdb2_hndl_tp* hndl, int col) except +
+    int cdb2_column_type(cdb2_hndl_tp* hndl, int col) except +
+    int cdb2_column_size(cdb2_hndl_tp* hndl, int col) except +
+    void* cdb2_column_value(cdb2_hndl_tp* hndl, int col) except +
+    const char* cdb2_errstr(cdb2_hndl_tp* hndl) except +
+    int cdb2_bind_param(cdb2_hndl_tp *hndl, const char *name, int type, const void *varaddr, int length) except +
+    int cdb2_bind_array(cdb2_hndl_tp *hndl, const char *name, cdb2_coltype, const void *varaddr, size_t count, size_t typelen) except +
+    int cdb2_clearbindings(cdb2_hndl_tp *hndl) except +
+    int cdb2_clear_ack(cdb2_hndl_tp *hndl) except +


### PR DESCRIPTION
While `libcdb2api` itself is implemented in C, the version used
internally at Bloomberg can optionally call into some plugins that are
implemented in C++, which could raise exceptions.

Ensure that `python-comdb2` catches any such exceptions, both for the
benefit of Bloomberg's internal Comdb2 users and to guard against the
possibility that C++ code is added to `libcdb2api` itself in the future.