### PR TITLE
Export `Value` and `ParameterValue` type aliases

### DIFF
--- a/comdb2/_about.py
+++ b/comdb2/_about.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.7.1"
+__version__ = "1.7.2"

--- a/comdb2/cdb2.py
+++ b/comdb2/cdb2.py
@@ -147,9 +147,20 @@ __all__ = [
     "HANDLE_FLAGS",
     "ColumnType",
     "ConnectionFlags",
+    "Value",
+    "ParameterValue",
 ]
 
 Value = Union[
+    None,
+    int,
+    float,
+    bytes,
+    str,
+    datetime.datetime,
+    DatetimeUs,
+]
+ParameterValue = Union[
     None,
     int,
     float,
@@ -348,7 +359,7 @@ class Handle:
     def execute(
         self,
         sql: str | bytes,
-        parameters: Mapping[str, Value] | None = None,
+        parameters: Mapping[str, ParameterValue] | None = None,
         *,
         column_types: Sequence[ColumnType] | None = None,
     ) -> Handle:

--- a/comdb2/dbapi2.py
+++ b/comdb2/dbapi2.py
@@ -249,7 +249,7 @@ import datetime
 import re
 
 from . import cdb2
-from .cdb2 import ColumnType, Row, Value
+from .cdb2 import ColumnType, Row, Value, ParameterValue
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import Any, List
 
@@ -287,6 +287,8 @@ __all__ = [
     "UniqueKeyConstraintError",
     "ForeignKeyConstraintError",
     "NonNullConstraintError",
+    "Value",
+    "ParameterValue",
 ]
 
 apilevel = "2.0"
@@ -958,7 +960,7 @@ class Cursor:
         self._description = None
         self._closed = True
 
-    def callproc(self, procname: str, parameters: Sequence[Value]) -> Sequence[Value]:
+    def callproc(self, procname: str, parameters: Sequence[ParameterValue]) -> Sequence[ParameterValue]:
         """Call a stored procedure with the given name.
 
         The ``parameters`` sequence must contain one entry for each argument
@@ -994,7 +996,7 @@ class Cursor:
     def execute(
         self,
         sql: str,
-        parameters: Mapping[str, Value] | None = None,
+        parameters: Mapping[str, ParameterValue] | None = None,
         *,
         column_types: Sequence[ColumnType] | None = None,
     ) -> Cursor:
@@ -1066,7 +1068,7 @@ class Cursor:
         return self
 
     def executemany(
-        self, sql: str, seq_of_parameters: Sequence[Mapping[str, Value]]
+        self, sql: str, seq_of_parameters: Sequence[Mapping[str, ParameterValue]]
     ) -> None:
         """Execute the same SQL statement repeatedly with different parameters.
 


### PR DESCRIPTION
resolves #78 

**Describe your changes**
`Value` type has been replaced by `ColumnValue` and `ParameterValue` types, both of which are exposed via both `cdb2.py` and `dbapi2.py` modules. Updated anything that uses the `Value` type to now use one of those two types.

**Testing performed**
Currently no tests. I could create a series of tests that look like below, but I'm not sure how value-added that is, since none of the other exports from any modules are similarly tested.

```python
# test_exports.py
def test_column_value_is_exported_from_dbapi2() -> None:
    from comdb2.dbapi2 import ColumnValue
```

or I could build a test that creates a fake package that imports these types and then runs `mypy`, but again I'm not sure how value-added that is.

**Additional context**
Spoke with Matt about this change and he suggested breaking it into the two types, since `Value` was used for both parameters and for column values returned inside result sets. I've adjusted functions that use `Value` to use one of the two replacements. We _aren't_ going to similarly expose the `Row` type since it just aliases `Any`, and it's not a big DevX burden to just use `Any` for `Row`.
