### PR TITLE
Add support for binding parameters by index

### DIFF
--- a/comdb2/_cdb2api.pxd
+++ b/comdb2/_cdb2api.pxd
@@ -76,6 +76,8 @@ cdef extern from "cdb2api.h" nogil:
     void* cdb2_column_value(cdb2_hndl_tp* hndl, int col) except +
     const char* cdb2_errstr(cdb2_hndl_tp* hndl) except +
     int cdb2_bind_param(cdb2_hndl_tp *hndl, const char *name, int type, const void *varaddr, int length) except +
+    int cdb2_bind_index(cdb2_hndl_tp *hndl, int index, int type, const void *varaddr, int length) except +
     int cdb2_bind_array(cdb2_hndl_tp *hndl, const char *name, cdb2_coltype, const void *varaddr, size_t count, size_t typelen) except +
+    int cdb2_bind_array_index(cdb2_hndl_tp *hndl, int index, cdb2_coltype, const void *varaddr, size_t count, size_t typelen) except +
     int cdb2_clearbindings(cdb2_hndl_tp *hndl) except +
     int cdb2_clear_ack(cdb2_hndl_tp *hndl) except +

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -68,14 +68,29 @@ Best Practices, Tips, and Tricks
        placeholders.  See `.dbapi2.Cursor.execute` and `.cdb2.Handle.execute`
        for details.
 
-#. For `.dbapi2`, be sure to escape any ``%`` signs in a query by doubling
-   them.  That is, instead of::
+#. When using `.dbapi2` but not parameter binding by position be sure to escape
+   any literal ``%`` signs in a query by doubling them.  That is, instead of::
 
-       c.execute("select * from tbl where col like 'foo%'")
+        cursor.execute(
+            "select * from log where msg like 'ERROR: %' and pid = %(pid)s",
+            {"pid": 1234},
+        )
 
    You need to write::
 
-       c.execute("select * from tbl where col like 'foo%%'")
+        cursor.execute(
+            "select * from log where msg like 'ERROR: %%' and pid = %(pid)s",
+            {"pid": 1234},
+        )
+
+   Also, if you don't want to pass any parameters to a `.dbapi2` query, it's
+   better to pass ``()`` than the default ``None`` value, because this removes
+   the need to escape any literal ``%`` signs that appear in the query::
+
+        cursor.execute(
+            "select * from log where msg like 'ERROR: %'",
+            (),
+        )
 
    See `.dbapi2.paramstyle` for an explanation of why.
 

--- a/tests/test_cdb2.py
+++ b/tests/test_cdb2.py
@@ -62,8 +62,26 @@ def test_binding_parameters():
     hndl.execute("insert into simple(key, val) values(@k, @v)", dict(k=3, v=4))
     assert hndl.get_effects()[0] == 1
 
+    hndl.execute("insert into simple(key, val) values(?, ?)", [5, 6])
+    assert hndl.get_effects()[0] == 1
+
     rows = list(hndl.execute("select key, val from simple order by key"))
-    assert rows == [[1, 2], [3, 4]]
+    assert rows == [[1, 2], [3, 4], [5, 6]]
+
+
+def test_binding_no_parameters():
+    hndl = cdb2.Handle("mattdb", "dev")
+    rows = list(hndl.execute("select 1 % 10"))
+    assert rows == [[1]]
+
+    rows = list(hndl.execute("select 2 % 10", {}))
+    assert rows == [[2]]
+
+    rows = list(hndl.execute("select 3 % 10", ()))
+    assert rows == [[3]]
+
+    rows = list(hndl.execute("select 4 % 10", []))
+    assert rows == [[4]]
 
 
 def test_commit_failures():


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #82 *

**Describe your changes**
Added support for binding by index by using a sequence of parameter values. Also checks if the value provided in this case is an array, which is not supported.
Examples:
`handle.execute("select ?", [10])`
This would output `10`

NOTE: when binding by index `%` does not need to be escaped in dbapi2. In all other cases using dbapi2 (even if not parameter binding), `%` needs to be escaped

https://peps.python.org/pep-0249/#id53 supports using a sequence of values with qmark param style

**Testing performed**
cdb2:
Added test to make sure binding an array by index does not work.
Added test that inserts parameters binded by index, similar to test that inserts parameters binded by value.

dbapi2:
Tested different behavior with `%`
Tested different sequences. Using list, tuple which should pass, string should fail.
Tested all data types, datetimes, overflow -- similar to binding by name
Tested array binding failure