### PR TITLE
Add asdatetime helper to DatetimeUs

### DIFF
--- a/comdb2/_cdb2_types.py
+++ b/comdb2/_cdb2_types.py
@@ -147,6 +147,20 @@ class DatetimeUs(datetime.datetime):
         dt = super().replace(*args, **kwargs)
         return self.fromdatetime(dt)
 
+    def as_datetime(self) -> datetime.datetime:
+        """Return a `datetime` representation."""
+        return datetime.datetime(
+            year=self.year,
+            day=self.day,
+            month=self.month,
+            hour=self.hour,
+            minute=self.minute,
+            second=self.second,
+            microsecond=self.microsecond,
+            tzinfo=self.tzinfo,
+            fold=self.fold,
+        )
+
 
 class ColumnType(enum.IntEnum):
     """This enum represents all known Comdb2 column types.

--- a/tests/test_cdb2_datetimeus.py
+++ b/tests/test_cdb2_datetimeus.py
@@ -91,6 +91,20 @@ def test_datetimeus_astimezone():
     assert type(dtu.astimezone(pytz.utc)) == cdb2.DatetimeUs
 
 
+def test_datetimeus_as_datetime_naive():
+    dtu = cdb2.DatetimeUs.fromtimestamp(time.time())
+    dt = dtu.as_datetime()
+    assert type(dt) == datetime.datetime
+    assert dt == dtu
+
+
+def test_datetimeus_as_datetime_with_tz():
+    dtu = cdb2.DatetimeUs.fromtimestamp(time.time(), tz=pytz.UTC)
+    dt = dtu.as_datetime()
+    assert type(dt) == datetime.datetime
+    assert dt == dtu
+
+
 def test_datetimeus_type_stickiness():
     def check(obj):
         assert isinstance(obj, cdb2.DatetimeUs)


### PR DESCRIPTION
Can be used to translate explictly the type where a subclass of datetimeus is not accepted (such as pydantic).

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>
