### PR TITLE
Drop support for Python 3.7, and fix CI on Ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,10 +85,10 @@ jobs:
           rm bloomberg-comdb2.tar.gz
         '
       - uses: actions/checkout@v4
-      - name: 'Set up Python 3.7'
+      - name: 'Set up Python 3.8'
         uses: actions/setup-python@v5  # note that this step overwrites the PKG_CONFIG_PATH variable
         with:
-          python-version: '3.7'  # the lowest version that we support in CI
+          python-version: '3.8'  # the lowest version that we support in CI
       - name: Build sdist
         run: '
           sudo apt-get install -qy pkg-config &&
@@ -114,7 +114,6 @@ jobs:
           - '3.10'
           - '3.9'
           - '3.8'
-          - '3.7'
     steps:
       - name: Download comdb2 repo with build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,12 +55,13 @@ jobs:
             mkdir bloomberg-comdb2/build &&
             cd bloomberg-comdb2/build &&
             cmake .. &&
-            make
+            make &&
+            sudo make install
           )
         '
       - name: Archive bloomberg-comdb2 repo with build artifacts
-        run: 'tar czvf bloomberg-comdb2.tar.gz bloomberg-comdb2/'
-      - name: Upload bloomberg-comdb2 repo with build artifacts
+        run: 'tar -C /opt -czvf bloomberg-comdb2.tar.gz bb'
+      - name: Upload built bloomberg-comdb2
         uses: actions/upload-artifact@v4
         with:
           name: bloomberg-comdb2
@@ -78,17 +79,10 @@ jobs:
           path: .
       - name: Install bloomberg-comdb2
         run: '
-          sudo apt-get install -qy
-            libevent-dev
-            liblz4-dev
-            libprotobuf-c-dev
-            libsqlite3-dev
-            libssl-dev
-            libunwind-dev
-            zlib1g-dev &&
-          tar xvf bloomberg-comdb2.tar.gz &&
-          (cd bloomberg-comdb2/build && sudo make install) &&
-          sudo rm -rf bloomberg-comdb2/ bloomberg-comdb2.tar.gz
+          sudo apt-get install -qy libprotobuf-c-dev libssl-dev libunwind-dev &&
+          sudo tar -C /opt -xzf bloomberg-comdb2.tar.gz &&
+          find /opt/bb &&
+          rm bloomberg-comdb2.tar.gz
         '
       - uses: actions/checkout@v4
       - name: 'Set up Python 3.7'
@@ -129,17 +123,10 @@ jobs:
           path: .
       - name: Install bloomberg-comdb2
         run: '
-          sudo apt-get install -qy
-            libevent-dev
-            liblz4-dev
-            libprotobuf-c-dev
-            libsqlite3-dev
-            libssl-dev
-            libunwind-dev
-            zlib1g-dev &&
-          tar xvf bloomberg-comdb2.tar.gz &&
-          (cd bloomberg-comdb2/build && sudo make install) &&
-          sudo rm -rf bloomberg-comdb2/ bloomberg-comdb2.tar.gz
+          sudo apt-get install -qy libprotobuf-c-dev libssl-dev libunwind-dev &&
+          sudo tar -C /opt -xzf bloomberg-comdb2.tar.gz &&
+          find /opt/bb &&
+          rm bloomberg-comdb2.tar.gz
         '
       - name: Start local comdb2 instance
         run: '

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.13-dev'
+          - '3.13'
           - '3.12'
           - '3.11'
           - '3.10'

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     packages=["comdb2"],
     install_requires=["pytz"],
     extras_require={"tests": ["python-dateutil>=2.6.0", "pytest"]},
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     ext_modules=[ccdb2],
     package_data={"comdb2": ["py.typed", "*.pyi"]},
 )


### PR DESCRIPTION
CI has been upgraded to run on Ubuntu 24.04. Rather than pin to 22.04, get things working instead. This necessitates dropping support for Python 3.7, as `actions/setup-python` does not support Python 3.7 on Ubuntu 24.04.