### PR TITLE
docs: Remove an unused setting from docs/conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -264,9 +264,6 @@ htmlhelp_basename = "Comdb2doc"
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
-# Don't highlight the code for the Python standard library datetime module.
-viewcode_import = False
-
 # Don't automatically infer types from type annotations.
 autodoc_typehints = "none"
 


### PR DESCRIPTION
This is now triggering warnings saying that:

    WARNING: The config value `viewcode_import' has type `bool';
             expected `NoneType'.

The comment says that we were trying to prevent the `viewcode` extension from generating HTML for the standard library `datetime` module, but even with this setting removed it doesn't do that. This may just be a holdover from some long ago version of Sphinx, but it no longer seems to be necessary or useful.
