### PR TITLE
Release version 1.8.0

### DIFF
--- a/comdb2/_about.py
+++ b/comdb2/_about.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "1.7.2"
+__version__ = "1.8.0"


### PR DESCRIPTION
This release adds support for binding parameters positionally with `?` placeholders. This feature was contributed by @chands10.

This release also adds a new `.as_datetime` method to `DatetimeUs` to allow converting a `DatetimeUs` to a `datetime.datetime`. This feature was contributed by @gaborbernat.

This release also drops support for Python 3.7, which has at this point is several years past end-of-life, and which has become too difficult to support in our CI.

Full diff since the last release is https://github.com/bloomberg/python-comdb2/compare/1.7.2...5c2e155a4dff0d43f000335b25208ee29dab04be